### PR TITLE
remove max length on settings password field

### DIFF
--- a/pynicotine/gtkgui/nicotine-settings.glade
+++ b/pynicotine/gtkgui/nicotine-settings.glade
@@ -140,7 +140,6 @@
                             <property name="width_request">100</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <property name="max_length">18</property>
                             <property name="visibility">False</property>
                             <property name="invisible_char">&#x2022;</property>
                             <property name="width_chars">10</property>


### PR DESCRIPTION
pygtk would silently truncate any password longer than the max length
when setting the field with set_text. fixes #5