### PR TITLE
Fix shares build / crashes caused by bogus metadata.

### DIFF
--- a/pynicotine/metadata_mutagen.py
+++ b/pynicotine/metadata_mutagen.py
@@ -5,6 +5,7 @@ from __future__ import division
 
 # Python modules
 import mutagen
+import os
 
 from mutagen.mp3 import MP3, MPEGInfo
 from mutagen.mp4 import MP4StreamInfoError
@@ -28,9 +29,12 @@ def detect(path):
 	except Exception, e:
 		log.addwarning("Mutagen crashed on '%s': %s" % (path, e))
 		return None
-	if not audio:
+	try:
+		audio.info
+	except:
 		# mutagen didn't think the file was audio
 		return None
+
 	if type(audio.info) == MPEGInfo:
 		return processMPEG(audio)
 	elif type(audio.info) == StreamInfo:
@@ -80,8 +84,17 @@ def processMPEG(audio):
 		"time": audio.info.length,
 	}
 def processFlac(audio):
+	filesize = os.path.getsize(audio.filename)
+
+	duration = audio.info.length
+
+	if duration > 0:
+		bitrate = filesize / duration * 8 / 1000
+	else:
+		bitrate = None
+
 	return {
-		"bitrate": (audio.info.bits_per_sample * audio.info.sample_rate / 1000),
+		"bitrate": bitrate,
 		"vbr": False,
 		"time": audio.info.length,
 	}
@@ -105,13 +118,22 @@ def processMonkeys(audio):
 	return info
 def processMP4(audio):
 	return {
-		"bitrate": audio.info.bitrate,
+		"bitrate": (audio.info.bitrate/1000),
 		"vbr": True,
 		"time": audio.info.length,
 	}
 def processASF(audio):
+	filesize = os.path.getsize(audio.filename)
+
+	duration = audio.info.length
+
+	if duration > 0:
+		bitrate = filesize / duration / 1000
+	else:
+		bitrate = None
+
 	return {
-		"bitrate": audio.info.bitrate,
+		"bitrate": bitrate,
 		"vbr": True,
 		"time": audio.info.length,
 	}

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -725,7 +725,7 @@ class Shares:
 						message.packObject(2) +
 						message.packObject(NetworkIntType(fileinfo[2][1])))
 				stream += msgbytes
-			except struct.error:
+			except:
 				log.addwarning(_("Found meta data that couldn't be encoded, possible corrupt file: '%(file)s' has a bitrate of %(bitrate)s kbs, a length of %(length)s seconds and a VBR of %(vbr)s" % {
 						'file':    fileinfo[0],
 						'bitrate': fileinfo[2][0],


### PR DESCRIPTION
These fixes address problems with shares building where the mutagen library is used to gather metadata. In some cases metadata would incorrectly not be generated and in others, bogus metadata (values out of bound) would be generated, particularly for asf/wmv/etc type files. This bogus metadata would cause crashes when the files where requested.
