### PR TITLE
Fix variable bitrate detection for MP3 files

### DIFF
--- a/pynicotine/metadata_mutagen.py
+++ b/pynicotine/metadata_mutagen.py
@@ -66,16 +66,15 @@ def processMusepack(audio):
 		"time": audio.info.length,
 	}
 def processMPEG(audio):
-	vbr = False
-	if audio.info.bitrate % 1000 != 0:
-		vbr = True
+	if hasattr(audio.info, 'bitrate_mode'):
+		from mutagen.mp3 import BitrateMode
+		vbr = audio.info.bitrate_mode == BitrateMode.VBR
 	else:
-		rates = audio.info._MPEGInfo__BITRATE[(audio.info.version, audio.info.layer)]
-		vbr = (audio.info.bitrate / 1000) not in rates
-	if vbr:
-		vbr = True
-	else:
-		vbr = False
+		if audio.info.bitrate % 1000 != 0:
+			vbr = True
+		else:
+			rates = audio.info._MPEGInfo__BITRATE[(audio.info.version, audio.info.layer)]
+			vbr = (audio.info.bitrate / 1000) not in rates
 	return {
 		"bitrate": (audio.info.bitrate/1000),
 		"vbr": vbr,


### PR DESCRIPTION
Starting with Mutagen commit 65d5910c12d9a4a4e0c7de0316b494ac064828c9 the code
for detecting the VBR detection in nicotine is no longer working as it was
using a private interface.

In Mutagen commit 1ffd7dd97b145316b56ac7bd586a8ad8779d2b6d a public interface
to detect the VBR for MP3 files was introduced. Use it by default and fallback
to the old code in case an old version of Mutagen is in use.