### PR TITLE
Increase chatroom loglines

### DIFF
--- a/pynicotine/gtkgui/settingswindow.glade
+++ b/pynicotine/gtkgui/settingswindow.glade
@@ -8398,7 +8398,7 @@ Clear</property>
                     <property name="secondary_icon_activatable">False</property>
                     <property name="primary_icon_sensitive">True</property>
                     <property name="secondary_icon_sensitive">True</property>
-                    <property name="adjustment">0 0 1000 1 10 0</property>
+                    <property name="adjustment">0 0 10000 1 10 0</property>
                   </widget>
                   <packing>
                     <property name="expand">False</property>


### PR DESCRIPTION
Per user request made via nicotine room ([><((((*>] on 2016-03-27).  Gives user the option to load more than 1000 previous chat lines when they rejoin a chat room.  The new limit is 10000.